### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/org.kde.ksudoku.json
+++ b/org.kde.ksudoku.json
@@ -15,7 +15,6 @@
         "--talk-name=org.kde.kuiserver"
     ],
     "modules": [
-        "shared-modules/glu/glu-9.json",
         {
             "name": "libkdegames",
             "buildsystem": "cmake-ninja",

--- a/org.kde.ksudoku.json
+++ b/org.kde.ksudoku.json
@@ -14,6 +14,14 @@
         "--talk-name=org.kde.JobViewServer",
         "--talk-name=org.kde.kuiserver"
     ],
+    "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/lib/qml",
+        "/share/carddecks",
+        "/share/doc",
+        "/share/qlogging-categories6"
+    ],
     "modules": [
         {
             "name": "libkdegames",


### PR DESCRIPTION
### Reduce the Flatpak size

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.

This PR also removes the /share/carddecks folder, which is not required for this game.

### Drop redundant glu module

AFAIK, no module requires it.